### PR TITLE
README: add WSL2 build and run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,54 @@ automatically at the first build attrmpt:
   * github.com/google/go-cmp - used only for testing
   * github.com/peterh/liner - line editor for the interactive shell
 
+### Building and running on Windows (WSL2)
+
+The project builds and runs under the Windows Subsystem for Linux
+(WSL2). The USB device emulation relies on the USB/IP kernel
+support (the `vhci_hcd` module), which recent WSL2 kernels already
+include, so a separate virtual machine is not required.
+
+The instructions below were tested on Ubuntu 24.04 under WSL2
+(kernel 6.6.87 microsoft-standard-WSL2).
+
+Install the build dependencies together with the USB/IP client
+tools:
+
+    sudo apt-get install -y \
+        golang gcc pkg-config make \
+        libavahi-client-dev libjpeg-dev libpng-dev \
+        libusb-1.0-0-dev python3-dev \
+        linux-tools-generic linux-tools-common linux-tools-virtual \
+        usbutils
+
+Note that Ubuntu has no standalone `usbip` package: the `usbip`
+client is shipped as part of `linux-tools` and installed under
+`/usr/lib/linux-tools-*/usbip`. Put it on the PATH, for example:
+
+    sudo ln -sf "$(ls /usr/lib/linux-tools-*/usbip | head -1)" \
+        /usr/local/bin/usbip
+
+Ubuntu does not package `libppd`, which is needed by a full
+`make`. To just build and try the virtual MFP simulator, build
+only that command:
+
+    go build -o mfp-virtual ./cmd/mfp-virtual
+
+Run the simulator in USB/IP mode:
+
+    ./mfp-virtual --usbip -d
+
+In another terminal, load the kernel module and attach the
+emulated device:
+
+    sudo modprobe vhci-hcd
+    sudo usbip attach -r localhost -b 1-1
+
+The virtual MFP now appears as a real USB device (`lsusb` lists it
+as `OpenPrinting Virtual MFP`) and can be driven by the usual Linux
+printing and scanning stack, including
+[ipp-usb](https://github.com/OpenPrinting/ipp-usb).
+
 ## Source tree organization
 
 ### import github.com/OpenPrinting/go-mfp/abstract"


### PR DESCRIPTION

This PR adds a short **"Building and running on Windows (WSL2)"** subsection to the README's **Building** section, documenting how to build `go-mfp` and run the USB device emulation under the Windows Subsystem for Linux.

### Motivation

It isn't obvious that the USB/IP-based device emulation works under WSL2 — but it does. Recent WSL2 kernels already ship the `vhci_hcd` module, so no separate virtual machine is needed. Capturing the exact steps should save other contributors the trial-and-error.

### The new section covers

- Confirmation that WSL2 works, because the kernel includes `vhci_hcd`.
- The build dependencies tested on Ubuntu 24.04.
- The gotcha that Ubuntu has no standalone `usbip` package — the client ships inside `linux-tools` (`/usr/lib/linux-tools-*/usbip`) and must be put on `PATH`.
- The note that Ubuntu doesn't package `libppd` (needed by a full `make`), with the option to build just `mfp-virtual`.
- How to run the simulator in USB/IP mode and attach the emulated device so it shows up as a real USB device.

### Tested

Tested on Ubuntu 24.04 under WSL2 (kernel `6.6.87-microsoft-standard-WSL2`): built `mfp-virtual`, ran it with `--usbip`, attached it via `usbip attach`, and confirmed it appears in `lsusb` as **OpenPrinting Virtual MFP**.
