### PR TITLE
Internal/evaluate: add image quality evaluation package

### DIFF
--- a/internal/Makefile
+++ b/internal/Makefile
@@ -1,3 +1,3 @@
-SUBDIRS	= assert env netstate random testutils zone
+SUBDIRS	= assert env evaluate netstate random testutils zone
 
 include ../Rules.mak

--- a/internal/evaluate/Makefile
+++ b/internal/evaluate/Makefile
@@ -1,0 +1,1 @@
+include ../../Rules.mak

--- a/internal/evaluate/doc.go
+++ b/internal/evaluate/doc.go
@@ -1,0 +1,10 @@
+// MFP - Multi-Function Printers and scanners toolkit
+// internal/evaluate - Image quality evaluation
+//
+// Copyright (C) 2026 Mohammad Arman (officialmdarman@gmail.com)
+// See LICENSE for license terms and conditions
+
+// Package evaluate provides image quality evaluation by comparing
+// a captured print output against the original test image using
+// the ImageComparator Python framework.
+package evaluate

--- a/internal/evaluate/evaluate.go
+++ b/internal/evaluate/evaluate.go
@@ -1,0 +1,177 @@
+// MFP - Multi-Function Printers and scanners toolkit
+// internal/evaluate - Image quality evaluation
+//
+// Copyright (C) 2026 Mohammad Arman (officialmdarman@gmail.com)
+// See LICENSE for license terms and conditions
+
+package evaluate
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/OpenPrinting/go-mfp/cpython"
+)
+
+// DefaultThreshold is the minimum overall quality score to pass.
+const DefaultThreshold = 0.95
+
+// Result holds the outcome of a single image comparison.
+type Result struct {
+	// Score is the overall quality score returned by ImageComparator
+	// (0.0 = worst, 1.0 = perfect match).
+	Score float64
+
+	// Passed reports whether Score >= the requested threshold.
+	Passed bool
+
+	// Details contains per-metric scores. It is only populated when
+	// verbose is requested or when the comparison fails (Score < threshold),
+	// to help diagnose which metric caused the failure.
+	Details map[string]float64
+}
+
+// Evaluator wraps the ImageComparator Python class and provides
+// a simple Go API for image quality comparison.
+//
+// Create with [NewEvaluator] and release with [Evaluator.Close].
+type Evaluator struct {
+	py  *cpython.Python
+	cls *cpython.Object // ImageComparator class
+}
+
+// NewEvaluator creates a new Evaluator by loading the ImageComparator
+// class from the given Python file path.
+//
+// comparatorPath must point to enhanced_comparison.py from the
+// OpenPrinting-Image-Evaluation project.
+func NewEvaluator(comparatorPath string) (*Evaluator, error) {
+	// Read the Python source file
+	data, err := os.ReadFile(comparatorPath)
+	if err != nil {
+		return nil, fmt.Errorf("evaluate: read %q: %w", comparatorPath, err)
+	}
+
+	// Create a new Python interpreter
+	py, err := cpython.NewPython()
+	if err != nil {
+		return nil, fmt.Errorf("evaluate: init Python: %w", err)
+	}
+
+	// Clean up interpreter on failure
+	defer func() {
+		if err != nil {
+			py.Close()
+		}
+	}()
+
+	// Load enhanced_comparison.py as a Python module
+	mod := py.Load(string(data), "enhanced_comparison", comparatorPath)
+	if err = mod.Err(); err != nil {
+		return nil, fmt.Errorf("evaluate: load %q: %w", comparatorPath, err)
+	}
+
+	// Get the ImageComparator class from the module
+	cls := mod.Get("ImageComparator")
+	if err = cls.Err(); err != nil {
+		return nil, fmt.Errorf("evaluate: ImageComparator class not found: %w", err)
+	}
+
+	return &Evaluator{py: py, cls: cls}, nil
+}
+
+// Close releases the Python interpreter and all resources held
+// by the Evaluator.
+func (e *Evaluator) Close() {
+	e.py.Close()
+}
+
+// Compare compares the captured image against the original and
+// returns a [Result].
+//
+//   - original: path to the reference PNG image
+//   - captured: path to the captured/printed PNG image
+//   - threshold: minimum score to pass (use [DefaultThreshold] if unsure)
+//   - verbose: if true, always populate Result.Details;
+//     if false, Details is only populated when the test fails
+func (e *Evaluator) Compare(original, captured string,
+	threshold float64, verbose bool) (*Result, error) {
+
+	// Instantiate: comp = ImageComparator(original, captured)
+	instance := e.cls.Call(original, captured)
+	if err := instance.Err(); err != nil {
+		return nil, fmt.Errorf("evaluate: ImageComparator(%q, %q): %w",
+			original, captured, err)
+	}
+
+	// Call: results = comp.run_all_comparisons()
+	method := instance.Get("run_all_comparisons")
+	if err := method.Err(); err != nil {
+		return nil, fmt.Errorf("evaluate: run_all_comparisons not found: %w", err)
+	}
+
+	results := method.Call()
+	if err := results.Err(); err != nil {
+		return nil, fmt.Errorf("evaluate: run_all_comparisons(): %w", err)
+	}
+
+	// Extract overall_quality score
+	scoreObj := results.GetItem("overall_quality")
+	if err := scoreObj.Err(); err != nil {
+		return nil, fmt.Errorf("evaluate: overall_quality not found: %w", err)
+	}
+
+	score, err := scoreObj.Float()
+	if err != nil {
+		return nil, fmt.Errorf("evaluate: overall_quality to float: %w", err)
+	}
+
+	passed := score >= threshold
+
+	res := &Result{
+		Score:  score,
+		Passed: passed,
+	}
+
+	// Populate per-metric details when verbose or on failure
+	if verbose || !passed {
+		details, err := extractDetails(results)
+		if err != nil {
+			return nil, fmt.Errorf("evaluate: extract metrics: %w", err)
+		}
+		res.Details = details
+	}
+
+	return res, nil
+}
+
+// extractDetails reads all key/value pairs from the Python results
+// dict and returns them as a Go map[string]float64.
+func extractDetails(results *cpython.Object) (map[string]float64, error) {
+	keys, err := results.Keys()
+	if err != nil {
+		return nil, err
+	}
+
+	details := make(map[string]float64, len(keys))
+	for _, k := range keys {
+		name, err := k.Unicode()
+		if err != nil {
+			continue
+		}
+
+		val := results.GetItem(name)
+		if val.Err() != nil {
+			continue
+		}
+
+		f, err := val.Float()
+		if err != nil {
+			continue
+		}
+
+		details[name] = f
+	}
+
+	return details, nil
+}

--- a/internal/evaluate/evaluate.go
+++ b/internal/evaluate/evaluate.go
@@ -7,14 +7,45 @@
 package evaluate
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
-
-	"github.com/OpenPrinting/go-mfp/cpython"
+	"os/exec"
 )
 
 // DefaultThreshold is the minimum overall quality score to pass.
 const DefaultThreshold = 0.95
+
+// runner is the Python script executed as a subprocess. It loads
+// ImageComparator from enhanced_comparison.py, runs the comparison,
+// and prints JSON results to stdout.
+//
+// argv: runner.py <comparator-path> <original-path> <captured-path>
+//
+// Stdout is redirected to stderr during import and comparison so that
+// any library warnings or progress messages do not corrupt the JSON output.
+const runner = `
+import sys, json, os, math
+
+_stdout = sys.stdout
+sys.stdout = sys.stderr
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(sys.argv[1])))
+from enhanced_comparison import ImageComparator
+comp = ImageComparator(sys.argv[2], sys.argv[3])
+results = comp.run_all_comparisons()
+
+sys.stdout = _stdout
+out = {}
+for k, v in results.items():
+    try:
+        f = float(v)
+        if not (math.isinf(f) or math.isnan(f)):
+            out[k] = f
+    except (TypeError, ValueError):
+        pass
+print(json.dumps(out))
+`
 
 // Result holds the outcome of a single image comparison.
 type Result struct {
@@ -31,59 +62,43 @@ type Result struct {
 	Details map[string]float64
 }
 
-// Evaluator wraps the ImageComparator Python class and provides
+// Evaluator runs ImageComparator in a subprocess and provides
 // a simple Go API for image quality comparison.
 //
 // Create with [NewEvaluator] and release with [Evaluator.Close].
 type Evaluator struct {
-	py  *cpython.Python
-	cls *cpython.Object // ImageComparator class
+	comparatorPath string // path to enhanced_comparison.py
+	runnerPath     string // temp file containing the runner script
 }
 
-// NewEvaluator creates a new Evaluator by loading the ImageComparator
-// class from the given Python file path.
-//
-// comparatorPath must point to enhanced_comparison.py from the
-// OpenPrinting-Image-Evaluation project.
+// NewEvaluator creates a new Evaluator for the given enhanced_comparison.py
+// path. A small Python runner script is written to a temp file; it is removed
+// when [Evaluator.Close] is called.
 func NewEvaluator(comparatorPath string) (*Evaluator, error) {
-	// Read the Python source file
-	data, err := os.ReadFile(comparatorPath)
+	if _, err := os.Stat(comparatorPath); err != nil {
+		return nil, fmt.Errorf("evaluate: %w", err)
+	}
+
+	f, err := os.CreateTemp("", "mfp-evaluate-*.py")
 	if err != nil {
-		return nil, fmt.Errorf("evaluate: read %q: %w", comparatorPath, err)
+		return nil, fmt.Errorf("evaluate: create runner: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(runner); err != nil {
+		os.Remove(f.Name())
+		return nil, fmt.Errorf("evaluate: write runner: %w", err)
 	}
 
-	// Create a new Python interpreter
-	py, err := cpython.NewPython()
-	if err != nil {
-		return nil, fmt.Errorf("evaluate: init Python: %w", err)
-	}
-
-	// Clean up interpreter on failure
-	defer func() {
-		if err != nil {
-			py.Close()
-		}
-	}()
-
-	// Load enhanced_comparison.py as a Python module
-	mod := py.Load(string(data), "enhanced_comparison", comparatorPath)
-	if err = mod.Err(); err != nil {
-		return nil, fmt.Errorf("evaluate: load %q: %w", comparatorPath, err)
-	}
-
-	// Get the ImageComparator class from the module
-	cls := mod.Get("ImageComparator")
-	if err = cls.Err(); err != nil {
-		return nil, fmt.Errorf("evaluate: ImageComparator class not found: %w", err)
-	}
-
-	return &Evaluator{py: py, cls: cls}, nil
+	return &Evaluator{
+		comparatorPath: comparatorPath,
+		runnerPath:     f.Name(),
+	}, nil
 }
 
-// Close releases the Python interpreter and all resources held
-// by the Evaluator.
+// Close removes the temporary runner script created by [NewEvaluator].
 func (e *Evaluator) Close() {
-	e.py.Close()
+	os.Remove(e.runnerPath)
 }
 
 // Compare compares the captured image against the original and
@@ -97,81 +112,33 @@ func (e *Evaluator) Close() {
 func (e *Evaluator) Compare(original, captured string,
 	threshold float64, verbose bool) (*Result, error) {
 
-	// Instantiate: comp = ImageComparator(original, captured)
-	instance := e.cls.Call(original, captured)
-	if err := instance.Err(); err != nil {
-		return nil, fmt.Errorf("evaluate: ImageComparator(%q, %q): %w",
-			original, captured, err)
-	}
-
-	// Call: results = comp.run_all_comparisons()
-	method := instance.Get("run_all_comparisons")
-	if err := method.Err(); err != nil {
-		return nil, fmt.Errorf("evaluate: run_all_comparisons not found: %w", err)
-	}
-
-	results := method.Call()
-	if err := results.Err(); err != nil {
-		return nil, fmt.Errorf("evaluate: run_all_comparisons(): %w", err)
-	}
-
-	// Extract overall_quality score
-	scoreObj := results.GetItem("overall_quality")
-	if err := scoreObj.Err(); err != nil {
-		return nil, fmt.Errorf("evaluate: overall_quality not found: %w", err)
-	}
-
-	score, err := scoreObj.Float()
+	cmd := exec.Command("python3", e.runnerPath, e.comparatorPath, original, captured)
+	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("evaluate: overall_quality to float: %w", err)
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("evaluate: python3: %w: %s", err, ee.Stderr)
+		}
+		return nil, fmt.Errorf("evaluate: python3: %w", err)
 	}
 
-	passed := score >= threshold
+	var scores map[string]float64
+	if err := json.Unmarshal(out, &scores); err != nil {
+		return nil, fmt.Errorf("evaluate: parse results: %w", err)
+	}
+
+	score, ok := scores["overall_quality"]
+	if !ok {
+		return nil, fmt.Errorf("evaluate: overall_quality not found in results")
+	}
 
 	res := &Result{
 		Score:  score,
-		Passed: passed,
+		Passed: score >= threshold,
 	}
 
-	// Populate per-metric details when verbose or on failure
-	if verbose || !passed {
-		details, err := extractDetails(results)
-		if err != nil {
-			return nil, fmt.Errorf("evaluate: extract metrics: %w", err)
-		}
-		res.Details = details
+	if verbose || !res.Passed {
+		res.Details = scores
 	}
 
 	return res, nil
-}
-
-// extractDetails reads all key/value pairs from the Python results
-// dict and returns them as a Go map[string]float64.
-func extractDetails(results *cpython.Object) (map[string]float64, error) {
-	keys, err := results.Keys()
-	if err != nil {
-		return nil, err
-	}
-
-	details := make(map[string]float64, len(keys))
-	for _, k := range keys {
-		name, err := k.Unicode()
-		if err != nil {
-			continue
-		}
-
-		val := results.GetItem(name)
-		if val.Err() != nil {
-			continue
-		}
-
-		f, err := val.Float()
-		if err != nil {
-			continue
-		}
-
-		details[name] = f
-	}
-
-	return details, nil
 }

--- a/internal/evaluate/evaluate_test.go
+++ b/internal/evaluate/evaluate_test.go
@@ -1,0 +1,116 @@
+// MFP - Multi-Function Printers and scanners toolkit
+// internal/evaluate - Image quality evaluation
+//
+// Copyright (C) 2026 Mohammad Arman (officialmdarman@gmail.com)
+// See LICENSE for license terms and conditions
+
+package evaluate
+
+import (
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"testing"
+)
+
+// makeTestPNG creates a temporary PNG file with the given fill color
+// and returns its path. The caller must remove it after use.
+func makeTestPNG(t *testing.T, r, g, b uint8) string {
+	t.Helper()
+
+	const size = 100
+	img := image.NewRGBA(image.Rect(0, 0, size, size))
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			img.Set(x, y, color.RGBA{R: r, G: g, B: b, A: 255})
+		}
+	}
+
+	f, err := os.CreateTemp("", "evaluate-test-*.png")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	defer f.Close()
+
+	if err := png.Encode(f, img); err != nil {
+		os.Remove(f.Name())
+		t.Fatalf("encode PNG: %v", err)
+	}
+
+	return f.Name()
+}
+
+// comparatorPath returns the path to enhanced_comparison.py.
+// It looks for the file next to the test binary (set via -comparator flag)
+// or falls back to a well-known development location.
+func comparatorPath(t *testing.T) string {
+	t.Helper()
+
+	candidates := []string{
+		"enhanced_comparison.py",
+		"/home/amrxg/enhanced_comparison.py",
+	}
+
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+
+	t.Skip("enhanced_comparison.py not found; skipping evaluator test")
+	return ""
+}
+
+// TestEvaluatorIdentical verifies that comparing an image with itself
+// returns a positive score without error. A solid-color test image has no
+// detectable keypoints or edges, so it will not reach DefaultThreshold;
+// the assertion only checks that the subprocess ran and returned a valid score.
+func TestEvaluatorIdentical(t *testing.T) {
+	path := comparatorPath(t)
+
+	ev, err := NewEvaluator(path)
+	if err != nil {
+		t.Fatalf("NewEvaluator: %v", err)
+	}
+	defer ev.Close()
+
+	img := makeTestPNG(t, 255, 0, 0)
+	defer os.Remove(img)
+
+	res, err := ev.Compare(img, img, DefaultThreshold, false)
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+
+	if res.Score <= 0 {
+		t.Errorf("identical images: expected positive score, got %.4f", res.Score)
+	}
+
+	t.Logf("identical images: score=%.4f", res.Score)
+}
+
+// TestEvaluatorDifferent verifies that comparing two completely different
+// images yields a low score that fails the default threshold.
+func TestEvaluatorDifferent(t *testing.T) {
+	path := comparatorPath(t)
+
+	ev, err := NewEvaluator(path)
+	if err != nil {
+		t.Fatalf("NewEvaluator: %v", err)
+	}
+	defer ev.Close()
+
+	original := makeTestPNG(t, 255, 0, 0) // red
+	captured := makeTestPNG(t, 0, 0, 255) // blue
+	defer os.Remove(original)
+	defer os.Remove(captured)
+
+	res, err := ev.Compare(original, captured, DefaultThreshold, true)
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+
+	t.Logf("different images: score=%.4f passed=%v", res.Score, res.Passed)
+	t.Logf("details: %v", res.Details)
+}


### PR DESCRIPTION
This PR adds a new internal/evaluate package that compares a captured print output against the original test image using Sanskar's ImageComparator framework.

Instead of using go-mfp's embedded CPython, the evaluator runs ImageComparator in a separate python3 subprocess. This is required because NumPy does not support Python sub-interpreters. The subprocess receives the two image paths as arguments and returns scores as JSON via stdout.

The package exposes:
 - NewEvaluator(comparatorPath) , writes a small Python runner to a
    temp file and verifies the comparator exists
 - Evaluator.Compare(original, captured, threshold, verbose) ,spawns python3, parses JSON output, returns Result with Score and Passed
 - Evaluator.Close() ,removes the temp runner file
 - DefaultThreshold = 0.95

  Per-metric details are only shown when the test fails or --verbose is set, keeping normal output concise