### PR TITLE
cmd/mfp-test: address review feedback for Phase 4

### DIFF
--- a/cmd/mfp-test/test/command.go
+++ b/cmd/mfp-test/test/command.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/OpenPrinting/go-mfp/argv"
 	"github.com/OpenPrinting/go-mfp/log"
@@ -73,6 +74,13 @@ var Command = argv.Command{
 			Name:      "--threshold",
 			Help:      fmt.Sprintf("minimum similarity score to pass (0.0-1.0, default %.2f)", DefaultThreshold),
 			HelpArg:   "score",
+			Singleton: true,
+			Validate:  argv.ValidateAny,
+		},
+		{
+			Name:      "--timeout",
+			Help:      fmt.Sprintf("document capture timeout (default %s)", DefaultTimeout),
+			HelpArg:   "duration",
 			Singleton: true,
 			Validate:  argv.ValidateAny,
 		},
@@ -240,12 +248,22 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 		threshold = t
 	}
 
+	// Parse capture timeout.
+	timeout := DefaultTimeout
+	if ts, ok := inv.Get("--timeout"); ok {
+		d, err := time.ParseDuration(ts)
+		if err != nil {
+			return fmt.Errorf("invalid timeout %q: %w", ts, err)
+		}
+		timeout = d
+	}
+
 	verbose := inv.Flag("-v")
 
 	// Run each test configuration.
 	for _, cfg := range configs {
 		log.Info(ctx, "running test: %s", cfg.Name)
-		result, err := RunTest(ctx, cfg, queueName, capture, threshold, verbose)
+		result, err := RunTest(ctx, cfg, queueName, capture, threshold, timeout, verbose)
 		if err != nil {
 			log.Info(ctx, "FAIL %s: %v", cfg.Name, err)
 			continue

--- a/cmd/mfp-test/test/command.go
+++ b/cmd/mfp-test/test/command.go
@@ -78,7 +78,11 @@ var Command = argv.Command{
 		},
 		{
 			Name: "--list",
-			Help: "list all test configurations and exit",
+			Help: "list all test configurations (full batch matrix) and exit",
+		},
+		{
+			Name: "--list-quick",
+			Help: "list quick test configurations and exit",
 		},
 		{
 			Name:      "--batch",
@@ -190,10 +194,17 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 		return fmt.Errorf("query printer capabilities: %w", err)
 	}
 
-	// --list: print all configurations and exit.
+	// --list: print all configurations (full batch matrix) and exit.
 	if inv.Flag("--list") {
-		configs := BatchMatrix(caps)
-		for _, cfg := range configs {
+		for _, cfg := range BatchMatrix(caps) {
+			fmt.Println(cfg.Name)
+		}
+		return nil
+	}
+
+	// --list-quick: print quick test configurations and exit.
+	if inv.Flag("--list-quick") {
+		for _, cfg := range QuickMatrix(caps) {
 			fmt.Println(cfg.Name)
 		}
 		return nil

--- a/cmd/mfp-test/test/command.go
+++ b/cmd/mfp-test/test/command.go
@@ -109,6 +109,10 @@ var Command = argv.Command{
 			Help: "run reduced test matrix (all sides × all color modes, first format only)",
 		},
 		{
+			Name: "--keep",
+			Help: "save captured document bytes to current directory",
+		},
+		{
 			Name:    "-v",
 			Aliases: []string{"--verbose"},
 			Help:    "enable verbose output",
@@ -258,12 +262,13 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 		timeout = d
 	}
 
+	keep := inv.Flag("--keep")
 	verbose := inv.Flag("-v")
 
 	// Run each test configuration.
 	for _, cfg := range configs {
 		log.Info(ctx, "running test: %s", cfg.Name)
-		result, err := RunTest(ctx, cfg, queueName, capture, threshold, timeout, verbose)
+		result, err := RunTest(ctx, cfg, queueName, capture, threshold, timeout, keep, verbose)
 		if err != nil {
 			log.Info(ctx, "FAIL %s: %v", cfg.Name, err)
 			continue

--- a/cmd/mfp-test/test/command.go
+++ b/cmd/mfp-test/test/command.go
@@ -71,7 +71,7 @@ var Command = argv.Command{
 		},
 		{
 			Name:      "--threshold",
-			Help:      "minimum similarity score to pass (0.0-1.0, default 0.95)",
+			Help:      fmt.Sprintf("minimum similarity score to pass (0.0-1.0, default %.2f)", DefaultThreshold),
 			HelpArg:   "score",
 			Singleton: true,
 			Validate:  argv.ValidateAny,

--- a/cmd/mfp-test/test/runner.go
+++ b/cmd/mfp-test/test/runner.go
@@ -20,6 +20,9 @@ import (
 // DefaultThreshold is the minimum similarity score required to pass a test.
 const DefaultThreshold = 0.95
 
+// DefaultTimeout is the default time to wait for a captured document.
+const DefaultTimeout = 30 * time.Second
+
 // TestResult holds the outcome of a single test run.
 type TestResult struct {
 	Config  TestConfig
@@ -35,7 +38,7 @@ type TestResult struct {
 // Image evaluation is not yet implemented; the function currently
 // reports success if the document was captured within the timeout.
 func RunTest(ctx context.Context, cfg TestConfig, queueName string,
-	capture *DocumentCapture, threshold float64, verbose bool) (*TestResult, error) {
+	capture *DocumentCapture, threshold float64, timeout time.Duration, verbose bool) (*TestResult, error) {
 
 	// Reset capture so we get only this job's document.
 	capture.Reset()
@@ -66,8 +69,8 @@ func RunTest(ctx context.Context, cfg TestConfig, queueName string,
 	// Wait for the document to arrive.
 	select {
 	case <-capture.OnDocument():
-	case <-time.After(30 * time.Second):
-		return nil, fmt.Errorf("timeout: no document received after 30s")
+	case <-time.After(timeout):
+		return nil, fmt.Errorf("timeout: no document received after %s", timeout)
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}

--- a/cmd/mfp-test/test/runner.go
+++ b/cmd/mfp-test/test/runner.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/OpenPrinting/go-mfp/log"
@@ -38,7 +39,7 @@ type TestResult struct {
 // Image evaluation is not yet implemented; the function currently
 // reports success if the document was captured within the timeout.
 func RunTest(ctx context.Context, cfg TestConfig, queueName string,
-	capture *DocumentCapture, threshold float64, timeout time.Duration, verbose bool) (*TestResult, error) {
+	capture *DocumentCapture, threshold float64, timeout time.Duration, keep, verbose bool) (*TestResult, error) {
 
 	// Reset capture so we get only this job's document.
 	capture.Reset()
@@ -84,6 +85,17 @@ func RunTest(ctx context.Context, cfg TestConfig, queueName string,
 	if verbose {
 		log.Info(ctx, "captured %d bytes format=%q job=%q",
 			len(d.Data), d.Params.Format, d.Params.JobName)
+	}
+
+	if keep {
+		// Derive a safe filename from the config name (replace / with -).
+		safeName := strings.ReplaceAll(cfg.Name, "/", "-")
+		outPath := safeName + ".captured"
+		if err := os.WriteFile(outPath, d.Data, 0644); err != nil {
+			log.Info(ctx, "keep: failed to save %s: %v", outPath, err)
+		} else {
+			log.Info(ctx, "keep: saved captured image to %s", outPath)
+		}
 	}
 
 	// Image evaluation will be wired here in Phase 5 once raster


### PR DESCRIPTION
This PR include the following changes.

  - Add --keep option to preserve captured images in the current directory
  - Add --timeout option to make the 30s capture timeout configurable
  - Fix --threshold help text to reference DefaultThreshold dynamically
  - Add --list-quick option alongside --list for the quick test matrix