### PR TITLE
cmd/mfp-test: fix exported symbols and improve usability

### DIFF
--- a/cmd/mfp-test/test/capture.go
+++ b/cmd/mfp-test/test/capture.go
@@ -15,32 +15,32 @@ import (
 	"github.com/OpenPrinting/go-mfp/abstract"
 )
 
-// CapturedDoc holds a single captured print document
+// capturedDoc holds a single captured print document
 // with its negotiated job parameters and raw bytes.
-type CapturedDoc struct {
+type capturedDoc struct {
 	Params abstract.PrinterRequest
 	Data   []byte
 }
 
-// DocumentCapture implements abstract.Printer and collects
+// documentCapture implements abstract.Printer and collects
 // all incoming print documents for later inspection.
 // It is safe for concurrent use.
-type DocumentCapture struct {
-	mu   sync.Mutex
-	docs []CapturedDoc
-	done chan struct{}
+type documentCapture struct {
+	mu       sync.Mutex
+	captured []capturedDoc
+	done     chan struct{}
 }
 
-// NewDocumentCapture creates a new DocumentCapture.
-func NewDocumentCapture() *DocumentCapture {
-	return &DocumentCapture{
+// newDocumentCapture creates a new documentCapture.
+func newDocumentCapture() *documentCapture {
+	return &documentCapture{
 		done: make(chan struct{}),
 	}
 }
 
 // PrintDocument implements abstract.Printer.
 // It reads the full document body and stores it along with params.
-func (dc *DocumentCapture) PrintDocument(
+func (dc *documentCapture) PrintDocument(
 	params abstract.PrinterRequest, body io.Reader) error {
 
 	data, err := io.ReadAll(body)
@@ -49,7 +49,7 @@ func (dc *DocumentCapture) PrintDocument(
 	}
 
 	dc.mu.Lock()
-	dc.docs = append(dc.docs, CapturedDoc{
+	dc.captured = append(dc.captured, capturedDoc{
 		Params: params,
 		Data:   data,
 	})
@@ -65,33 +65,28 @@ func (dc *DocumentCapture) PrintDocument(
 	return nil
 }
 
-// OnDocument returns a channel that is closed when the first
+// onDocument returns a channel that is closed when the first
 // document is received. Useful for waiting without polling.
-func (dc *DocumentCapture) OnDocument() <-chan struct{} {
+func (dc *documentCapture) onDocument() <-chan struct{} {
 	return dc.done
 }
 
-// Wait blocks until at least one document has been captured.
-func (dc *DocumentCapture) Wait() {
-	<-dc.done
-}
-
-// Docs returns a snapshot of all captured documents so far.
-func (dc *DocumentCapture) Docs() []CapturedDoc {
+// docs returns a snapshot of all captured documents so far.
+func (dc *documentCapture) docs() []capturedDoc {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
 
-	out := make([]CapturedDoc, len(dc.docs))
-	copy(out, dc.docs)
+	out := make([]capturedDoc, len(dc.captured))
+	copy(out, dc.captured)
 	return out
 }
 
-// Reset clears all captured documents and resets the OnDocument
+// reset clears all captured documents and resets the onDocument
 // signal so the capture can be reused for the next test run.
-func (dc *DocumentCapture) Reset() {
+func (dc *documentCapture) reset() {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
 
-	dc.docs = nil
+	dc.captured = nil
 	dc.done = make(chan struct{})
 }

--- a/cmd/mfp-test/test/command.go
+++ b/cmd/mfp-test/test/command.go
@@ -24,11 +24,11 @@ import (
 	"github.com/OpenPrinting/go-mfp/transport"
 )
 
-// DefaultTCPPort is the default IPP server TCP port.
-const DefaultTCPPort = 60000
+// defaultTCPPort is the default IPP server TCP port.
+const defaultTCPPort = 60000
 
-// DefaultQueueName is the default CUPS queue name.
-const DefaultQueueName = "mfp-test"
+// defaultQueueName is the default CUPS queue name.
+const defaultQueueName = "mfp-test"
 
 // Command is the mfp-test command description.
 var Command = argv.Command{
@@ -48,7 +48,7 @@ var Command = argv.Command{
 		{
 			Name:      "-P",
 			Aliases:   []string{"--port"},
-			Help:      fmt.Sprintf("IPP server TCP port (default %d)", DefaultTCPPort),
+			Help:      fmt.Sprintf("IPP server TCP port (default %d)", defaultTCPPort),
 			HelpArg:   "port",
 			Singleton: true,
 			Validate:  argv.ValidateUint16,
@@ -56,7 +56,7 @@ var Command = argv.Command{
 		{
 			Name:      "-n",
 			Aliases:   []string{"--name"},
-			Help:      fmt.Sprintf("CUPS queue name (default %q)", DefaultQueueName),
+			Help:      fmt.Sprintf("CUPS queue name (default %q)", defaultQueueName),
 			HelpArg:   "name",
 			Singleton: true,
 			Validate:  argv.ValidateAny,
@@ -72,14 +72,14 @@ var Command = argv.Command{
 		},
 		{
 			Name:      "--threshold",
-			Help:      fmt.Sprintf("minimum similarity score to pass (0.0-1.0, default %.2f)", DefaultThreshold),
+			Help:      fmt.Sprintf("minimum similarity score to pass (0.0-1.0, default %.2f)", defaultThreshold),
 			HelpArg:   "score",
 			Singleton: true,
 			Validate:  argv.ValidateAny,
 		},
 		{
 			Name:      "--timeout",
-			Help:      fmt.Sprintf("document capture timeout (default %s)", DefaultTimeout),
+			Help:      fmt.Sprintf("document capture timeout (default %s)", defaultTimeout),
 			HelpArg:   "duration",
 			Singleton: true,
 			Validate:  argv.ValidateAny,
@@ -148,7 +148,7 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 	}
 
 	// Parse port number
-	port := DefaultTCPPort
+	port := defaultTCPPort
 	if portStr, ok := inv.Get("-P"); ok {
 		p, err := strconv.Atoi(portStr)
 		if err != nil {
@@ -158,7 +158,7 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 	}
 
 	// Create document capture backend
-	capture := NewDocumentCapture()
+	capture := newDocumentCapture()
 
 	// Create virtual IPP printer from model and hook capture into it
 	ippPrinter := model.NewIPPServer()
@@ -184,7 +184,7 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 	defer srvr.Close()
 
 	// Get CUPS queue name
-	queueName := DefaultQueueName
+	queueName := defaultQueueName
 	if name, ok := inv.Get("-n"); ok {
 		queueName = name
 	}
@@ -201,14 +201,14 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 	log.Info(ctx, "CUPS queue %q ready at %s", queueName, ippURL)
 
 	// Query printer capabilities for test matrix generation.
-	caps, err := QueryPrinterCaps(ctx, ippURL)
+	caps, err := queryPrinterCaps(ctx, ippURL)
 	if err != nil {
 		return fmt.Errorf("query printer capabilities: %w", err)
 	}
 
 	// --list: print all configurations (full batch matrix) and exit.
 	if inv.Flag("--list") {
-		for _, cfg := range BatchMatrix(caps) {
+		for _, cfg := range batchMatrix(caps) {
 			fmt.Println(cfg.Name)
 		}
 		return nil
@@ -216,7 +216,7 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 
 	// --list-quick: print quick test configurations and exit.
 	if inv.Flag("--list-quick") {
-		for _, cfg := range QuickMatrix(caps) {
+		for _, cfg := range quickMatrix(caps) {
 			fmt.Println(cfg.Name)
 		}
 		return nil
@@ -224,26 +224,26 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 
 	// Determine which test configurations to run.
 	// One of --batch, --quick, or --single must be explicitly set.
-	var configs []TestConfig
+	var configs []testConfig
 	switch {
 	case inv.Flag("--batch"):
-		configs = BatchMatrix(caps)
+		configs = batchMatrix(caps)
 	case inv.Flag("--quick"):
-		configs = QuickMatrix(caps)
+		configs = quickMatrix(caps)
 	default:
 		if spec, ok := inv.Get("--single"); ok {
-			cfg, err := SingleConfig(spec)
+			cfg, err := singleConfig(spec)
 			if err != nil {
 				return err
 			}
-			configs = []TestConfig{*cfg}
+			configs = []testConfig{*cfg}
 		} else {
 			return fmt.Errorf("no test mode specified: use --batch, --quick, or --single")
 		}
 	}
 
 	// Parse similarity threshold.
-	threshold := DefaultThreshold
+	threshold := defaultThreshold
 	if ts, ok := inv.Get("--threshold"); ok {
 		var t float64
 		if _, err := fmt.Sscanf(ts, "%f", &t); err != nil {
@@ -253,7 +253,7 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 	}
 
 	// Parse capture timeout.
-	timeout := DefaultTimeout
+	timeout := defaultTimeout
 	if ts, ok := inv.Get("--timeout"); ok {
 		d, err := time.ParseDuration(ts)
 		if err != nil {
@@ -268,7 +268,7 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 	// Run each test configuration.
 	for _, cfg := range configs {
 		log.Info(ctx, "running test: %s", cfg.Name)
-		result, err := RunTest(ctx, cfg, queueName, capture, threshold, timeout, keep, verbose)
+		result, err := runTest(ctx, cfg, queueName, capture, threshold, timeout, keep, verbose)
 		if err != nil {
 			log.Info(ctx, "FAIL %s: %v", cfg.Name, err)
 			continue

--- a/cmd/mfp-test/test/command.go
+++ b/cmd/mfp-test/test/command.go
@@ -223,6 +223,7 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 	}
 
 	// Determine which test configurations to run.
+	// One of --batch, --quick, or --single must be explicitly set.
 	var configs []TestConfig
 	switch {
 	case inv.Flag("--batch"):
@@ -237,8 +238,7 @@ func cmdTestHandler(ctx context.Context, inv *argv.Invocation) error {
 			}
 			configs = []TestConfig{*cfg}
 		} else {
-			// Default: single run with printer defaults.
-			configs = QuickMatrix(caps)
+			return fmt.Errorf("no test mode specified: use --batch, --quick, or --single")
 		}
 	}
 

--- a/cmd/mfp-test/test/matrix.go
+++ b/cmd/mfp-test/test/matrix.go
@@ -16,26 +16,26 @@ import (
 	"github.com/OpenPrinting/go-mfp/proto/ipp"
 )
 
-// PrinterCaps holds the queried printer capabilities used to generate
+// printerCaps holds the queried printer capabilities used to generate
 // the test matrix.
-type PrinterCaps struct {
+type printerCaps struct {
 	Sides      []ipp.KwSides
 	ColorModes []string
 	Formats    []string
 }
 
-// TestConfig represents one specific combination of print parameters
+// testConfig represents one specific combination of print parameters
 // to exercise in a test run.
-type TestConfig struct {
+type testConfig struct {
 	Name      string
 	Sides     ipp.KwSides
 	ColorMode string
 	Format    string
 }
 
-// QueryPrinterCaps queries the virtual IPP printer for its supported
-// attribute values and returns them as a PrinterCaps.
-func QueryPrinterCaps(ctx context.Context, printerURL string) (*PrinterCaps, error) {
+// queryPrinterCaps queries the virtual IPP printer for its supported
+// attribute values and returns them as a printerCaps.
+func queryPrinterCaps(ctx context.Context, printerURL string) (*printerCaps, error) {
 	u, err := url.Parse(printerURL)
 	if err != nil {
 		return nil, fmt.Errorf("matrix: parse printer URL: %w", err)
@@ -48,7 +48,7 @@ func QueryPrinterCaps(ctx context.Context, printerURL string) (*PrinterCaps, err
 		return nil, fmt.Errorf("matrix: query printer attributes: %w", err)
 	}
 
-	caps := &PrinterCaps{
+	caps := &printerCaps{
 		Sides:      attrs.SidesSupported,
 		ColorModes: attrs.PrintColorModeSupported,
 		Formats:    attrs.DocumentFormatSupported,
@@ -73,14 +73,14 @@ func configName(sides ipp.KwSides, color, format string) string {
 	return fmt.Sprintf("%s/%s/%s", sides, color, format)
 }
 
-// BatchMatrix returns every combination of sides × color mode × format.
+// batchMatrix returns every combination of sides × color mode × format.
 // This is the exhaustive test matrix.
-func BatchMatrix(caps *PrinterCaps) []TestConfig {
-	var configs []TestConfig
+func batchMatrix(caps *printerCaps) []testConfig {
+	var configs []testConfig
 	for _, sides := range caps.Sides {
 		for _, color := range caps.ColorModes {
 			for _, format := range caps.Formats {
-				configs = append(configs, TestConfig{
+				configs = append(configs, testConfig{
 					Name:      configName(sides, color, format),
 					Sides:     sides,
 					ColorMode: color,
@@ -92,16 +92,16 @@ func BatchMatrix(caps *PrinterCaps) []TestConfig {
 	return configs
 }
 
-// QuickMatrix returns a reduced matrix: all sides × all color modes,
+// quickMatrix returns a reduced matrix: all sides × all color modes,
 // but only the first document format. Duplex/simplex and color/mono
 // are tested independently; format variation is omitted to keep the
 // run short.
-func QuickMatrix(caps *PrinterCaps) []TestConfig {
+func quickMatrix(caps *printerCaps) []testConfig {
 	format := caps.Formats[0]
-	var configs []TestConfig
+	var configs []testConfig
 	for _, sides := range caps.Sides {
 		for _, color := range caps.ColorModes {
-			configs = append(configs, TestConfig{
+			configs = append(configs, testConfig{
 				Name:      configName(sides, color, format),
 				Sides:     sides,
 				ColorMode: color,
@@ -112,10 +112,10 @@ func QuickMatrix(caps *PrinterCaps) []TestConfig {
 	return configs
 }
 
-// SingleConfig parses a configuration name of the form
-// "sides/color-mode/format" and returns the corresponding TestConfig.
+// singleConfig parses a configuration name of the form
+// "sides/color-mode/format" and returns the corresponding testConfig.
 // This is used with --single to reproduce a specific known bug.
-func SingleConfig(spec string) (*TestConfig, error) {
+func singleConfig(spec string) (*testConfig, error) {
 	parts := strings.SplitN(spec, "/", 3)
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("matrix: --single requires sides/color-mode/format, got %q", spec)
@@ -128,7 +128,7 @@ func SingleConfig(spec string) (*TestConfig, error) {
 	default:
 		return nil, fmt.Errorf("matrix: unknown sides value %q", sides)
 	}
-	return &TestConfig{
+	return &testConfig{
 		Name:      spec,
 		Sides:     sides,
 		ColorMode: parts[1],

--- a/cmd/mfp-test/test/runner.go
+++ b/cmd/mfp-test/test/runner.go
@@ -52,7 +52,7 @@ func RunTest(ctx context.Context, cfg TestConfig, queueName string,
 	defer os.Remove(imgPath)
 
 	// Build lp options for the test configuration.
-	lpArgs := []string{"-d", queueName}
+	lpArgs := []string{"-d", queueName, "-t", "mfp-test/" + cfg.Name}
 	if cfg.Sides != "" {
 		lpArgs = append(lpArgs, "-o", "sides="+string(cfg.Sides))
 	}

--- a/cmd/mfp-test/test/runner.go
+++ b/cmd/mfp-test/test/runner.go
@@ -88,13 +88,12 @@ func RunTest(ctx context.Context, cfg TestConfig, queueName string,
 	}
 
 	if keep {
-		// Derive a safe filename from the config name (replace / with -).
 		safeName := strings.ReplaceAll(cfg.Name, "/", "-")
-		outPath := safeName + ".captured"
+		outPath := safeName + mimeToExt(d.Params.Format)
 		if err := os.WriteFile(outPath, d.Data, 0644); err != nil {
 			log.Info(ctx, "keep: failed to save %s: %v", outPath, err)
 		} else {
-			log.Info(ctx, "keep: saved captured image to %s", outPath)
+			log.Info(ctx, "keep: saved captured document to %s", outPath)
 		}
 	}
 
@@ -107,4 +106,33 @@ func RunTest(ctx context.Context, cfg TestConfig, queueName string,
 		Score:  score,
 		Passed: score >= threshold,
 	}, nil
+}
+
+// mimeToExt returns a file extension for a MIME type.
+// Gzip-compressed variants get a double extension (e.g. .pdf.gz).
+func mimeToExt(mime string) string {
+	switch mime {
+	case "application/pdf":
+		return ".pdf"
+	case "application/postscript":
+		return ".ps"
+	case "image/jpeg":
+		return ".jpg"
+	case "image/jpeg+gzip":
+		return ".jpg.gz"
+	case "image/png":
+		return ".png"
+	case "image/pwg-raster":
+		return ".pwg"
+	case "image/urf":
+		return ".urf"
+	case "image/vnd.cups-raster":
+		return ".ras"
+	case "application/vnd.cups-pdf":
+		return ".cups.pdf"
+	case "application/vnd.cups-postscript":
+		return ".cups.ps"
+	default:
+		return ".bin"
+	}
 }

--- a/cmd/mfp-test/test/runner.go
+++ b/cmd/mfp-test/test/runner.go
@@ -18,31 +18,31 @@ import (
 	"github.com/OpenPrinting/go-mfp/log"
 )
 
-// DefaultThreshold is the minimum similarity score required to pass a test.
-const DefaultThreshold = 0.95
+// defaultThreshold is the minimum similarity score required to pass a test.
+const defaultThreshold = 0.95
 
-// DefaultTimeout is the default time to wait for a captured document.
-const DefaultTimeout = 30 * time.Second
+// defaultTimeout is the default time to wait for a captured document.
+const defaultTimeout = 30 * time.Second
 
-// TestResult holds the outcome of a single test run.
-type TestResult struct {
-	Config  TestConfig
+// testResult holds the outcome of a single test run.
+type testResult struct {
+	Config  testConfig
 	Score   float64
 	Passed  bool
 	Details map[string]float64
 }
 
-// RunTest runs a single print test using the given configuration:
+// runTest runs a single print test using the given configuration:
 // generates a test PNG, sends it to the CUPS queue with the specified
 // job attributes, waits for capture, and returns the test result.
 //
 // Image evaluation is not yet implemented; the function currently
 // reports success if the document was captured within the timeout.
-func RunTest(ctx context.Context, cfg TestConfig, queueName string,
-	capture *DocumentCapture, threshold float64, timeout time.Duration, keep, verbose bool) (*TestResult, error) {
+func runTest(ctx context.Context, cfg testConfig, queueName string,
+	capture *documentCapture, threshold float64, timeout time.Duration, keep, verbose bool) (*testResult, error) {
 
 	// Reset capture so we get only this job's document.
-	capture.Reset()
+	capture.reset()
 
 	// Generate a fresh test image for this run.
 	imgPath, err := generateTestPNG()
@@ -69,19 +69,19 @@ func RunTest(ctx context.Context, cfg TestConfig, queueName string,
 
 	// Wait for the document to arrive.
 	select {
-	case <-capture.OnDocument():
+	case <-capture.onDocument():
 	case <-time.After(timeout):
 		return nil, fmt.Errorf("timeout: no document received after %s", timeout)
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
 
-	docs := capture.Docs()
-	if len(docs) == 0 {
+	captured := capture.docs()
+	if len(captured) == 0 {
 		return nil, fmt.Errorf("capture returned no documents")
 	}
 
-	d := docs[len(docs)-1]
+	d := captured[len(captured)-1]
 	if verbose {
 		log.Info(ctx, "captured %d bytes format=%q job=%q",
 			len(d.Data), d.Params.Format, d.Params.JobName)
@@ -101,7 +101,7 @@ func RunTest(ctx context.Context, cfg TestConfig, queueName string,
 	// conversion (captured bytes → PNG) is implemented. For now,
 	// a successful capture counts as a pass with a placeholder score.
 	score := 1.0
-	return &TestResult{
+	return &testResult{
 		Config: cfg,
 		Score:  score,
 		Passed: score >= threshold,
@@ -109,7 +109,7 @@ func RunTest(ctx context.Context, cfg TestConfig, queueName string,
 }
 
 // mimeToExt returns a file extension for a MIME type.
-// Gzip-compressed variants get a double extension (e.g. .pdf.gz).
+// Gzip-compressed variants get a double extension (e.g. .jpg.gz).
 func mimeToExt(mime string) string {
 	switch mime {
 	case "application/pdf":


### PR DESCRIPTION
Following PR contains the following changes.

  - Require --batch, --quick or --single explicitly; no default mode
  - Add job name via lp -t for readable print job titles
  - Save captured files with proper extension based on MIME type
  - Unexport all symbols except Command